### PR TITLE
Adding testbook dependency in requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pytest==7.1.2
 ipykernel==6.15.1
 pandas==1.4.3
 numpy==1.23.1
+testbook


### PR DESCRIPTION
Hi @alfredodeza, 
During office hours today, I noticed a bug where test cases were failing due to missing "testbook" dependency in the requirements.txt file. I have added it to the requirements.txt file